### PR TITLE
Add access to all headers in request response.

### DIFF
--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -47,6 +47,7 @@ export interface ProgressEvent {
 }
 
 export interface Headers {
+  all: { [key: string]: string };
   get(key: string): string;
 }
 
@@ -140,10 +141,21 @@ export default function request(
 }
 
 class HeadersClass {
-  private data: any;
+  private data: { [key: string]: string };
 
-  constructor(headers: any) {
+  constructor(headers: { [key: string]: string }) {
     this.data = headers;
+  }
+
+  get all() {
+    const { data } = this;
+    return Object.keys(data).reduce(
+      (headers: { [key: string]: string }, key) => {
+        headers[key.toLowerCase()] = data[key];
+        return headers;
+      },
+      {}
+    );
   }
 
   get(key: string) {

--- a/tests/unit/lib/request.ts
+++ b/tests/unit/lib/request.ts
@@ -1,5 +1,5 @@
 import * as moxios from 'moxios';
-import request from '../../../src/lib/request';
+import request, { Response } from '../../../src/lib/request';
 
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
@@ -26,7 +26,8 @@ registerSuite('lib/request', {
             statusText: 'OK',
             response: 'foo',
             headers: {
-              'Content-Type': 'text/plain'
+              'Content-Type': 'text/plain',
+              'A-Test-Header': 'Some Value'
             }
           });
         })
@@ -52,6 +53,16 @@ registerSuite('lib/request', {
               response.headers.get('content-type'),
               'text/plain',
               'Unexpected content type'
+            );
+            assert.equal(
+              response.headers.all['content-type'],
+              'text/plain',
+              'Unexpected content type for content-type'
+            );
+            assert.equal(
+              response.headers.all['a-test-header'],
+              'Some Value',
+              'Unexpected content type for a-test-header'
             );
             return response.text();
           })


### PR DESCRIPTION
In my work on adding a new WebDriver tunnel, https://github.com/theintern/digdug/pull/73, I need access to all of the HTTP headers in the response returned by `request`.